### PR TITLE
User blocking

### DIFF
--- a/client.py
+++ b/client.py
@@ -3,30 +3,55 @@ import os
 import random
 import threading
 
+
 def outgoing():
-	while True:
-		global stop_threads
-		message = input(f"{nickname} > ")
-		if message:
-			if message == "exit":
-				irc.close()
-				stop_threads = True
-			else:    
-				irc.send(channel, message)
-		if stop_threads:
-			break
-    
+    while True:
+        global stop_threads
+        message = input(f"{nickname} > ")
+
+        # broke up the message into whitespace, with the 1st element being put into a variable called cmd
+        if len(message) != 0:
+            cmd = message.split()[0]
+
+        # if any of these commands are recognized it performs them, otherwise just sends the message.
+        if message:
+            # only changed which variable is being compared to string "exit"
+            if cmd == "exit":
+                irc.close()
+                stop_threads = True
+            # command for blocking a user. Assumes the user to be blocked is the 2nd argument of the message
+            elif cmd == "/block":
+                global blocklist
+                blocklist.append(message.split()[1])
+            # command for unblocking a user. Assumes the blocked user is the 2nd argument of the message
+            elif cmd == "/unblock":
+                blocklist.remove(message.split()[1])
+            else:
+                irc.send(channel, message)
+        if stop_threads:
+            break
+
+
 def incoming():
+    while True:
+        global stop_threads
+        global blocklist
+        blocked = False
+        text = irc.get_text()
+        # checks if any mention of a blocked user is in the message. If so blocks the message.
+        # this approach is overkill, and I will narrow it down to only messages sent by blocked users
+        for i in blocklist:
+            if i in text:
+                blocked = True
+        # if no mention of a blocked user in message, prints the message.
+        if not blocked:
+            print("\n", text)
 
-	while True:
-		global stop_threads
-		text = irc.get_text()
-		print("\n", text)
-		
-		if stop_threads:
-			break
-	
+        if stop_threads:
+            break
 
+
+blocklist = []  # list of blocked users
 channel = input("Enter channel name:> ")
 server = "irc.freenode.net"
 nickname = input("Enter Nick:> ")

--- a/client.py
+++ b/client.py
@@ -38,14 +38,20 @@ def incoming():
         global blocklist
         blocked = False
         text = irc.get_text()
+        if text != None:
+            # the message is always after the : symbol
+            message = text.split(':')
+            # user is always before the ! symbol
+            user = text.split('!')
+        user[0].strip()
         # checks if any mention of a blocked user is in the message. If so blocks the message.
         # this approach is overkill, and I will narrow it down to only messages sent by blocked users
         for i in blocklist:
-            if i in text:
+            if i in user[0]:
                 blocked = True
         # if no mention of a blocked user in message, prints the message.
         if not blocked:
-            print("\n", text)
+            print("\n", user[0], ": ", message[len(message) - 1])
 
         if stop_threads:
             break

--- a/client.py
+++ b/client.py
@@ -22,10 +22,10 @@ def outgoing():
             # command for blocking a user. Assumes the user to be blocked is the 2nd argument of the message
             elif cmd == "/block":
                 global blocklist
-                blocklist.append(message.split()[1])
+                blocklist[message.split()[1]] = True
             # command for unblocking a user. Assumes the blocked user is the 2nd argument of the message
             elif cmd == "/unblock":
-                blocklist.remove(message.split()[1])
+                blocklist[message.split()[1]] = False
             else:
                 irc.send(channel, message)
         if stop_threads:
@@ -44,20 +44,16 @@ def incoming():
             # user is always before the ! symbol
             user = text.split('!')
         user[0].strip()
-        # checks if any mention of a blocked user is in the message. If so blocks the message.
-        # this approach is overkill, and I will narrow it down to only messages sent by blocked users
-        for i in blocklist:
-            if i in user[0]:
-                blocked = True
+
         # if no mention of a blocked user in message, prints the message.
-        if not blocked:
+        if not blocklist[user[0]]:
             print("\n", user[0], ": ", message[len(message) - 1])
 
         if stop_threads:
             break
 
 
-blocklist = []  # list of blocked users
+blocklist = {}  # list of blocked users
 channel = input("Enter channel name:> ")
 server = "irc.freenode.net"
 nickname = input("Enter Nick:> ")


### PR DESCRIPTION
This version has the blocklist as a dictionary instead of a list, which should be more efficient. The block and unblock commands need to be preceded by a '/' to be used in the chat (ex. /block) .